### PR TITLE
Add initial GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,43 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  # Run the tests in various configurations
+  pytest:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      # Keep running even if one variation of the job fail
+      fail-fast: false
+      matrix:
+        include:
+          python: ["3.10", "3.11", "3.12"]
+
+    steps:
+      # actions/setup-python@v5 has built-in functionality for caching and restoring dependencies. 
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip' # caching pip dependencies
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run the tests
+        run: |
+          python -m pytest -v 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,11 +18,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     strategy:
-      # Keep running even if one variation of the job fail
+      # Keep running even if one variation of the job fails
       fail-fast: false
       matrix:
-        include:
-          python: ["3.10", "3.11", "3.12"]
+          python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       # actions/setup-python@v5 has built-in functionality for caching and restoring dependencies. 


### PR DESCRIPTION
- The workflow is triggered on push and pull requests to the `main` branch.
- Tests are run against `Python` versions 3.10, 3.11, and 3.12 using a matrix strategy.
- Utilizes `actions/setup-python@v5` to cache `pip` dependencies, improving build times.
- Installs Python dependencies specified in `requirements.txt` before running tests using `pytest`