### PR TITLE
Use Codecov to check code coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,14 +48,19 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip' # caching pip dependencies
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 
-      - name: Run the tests
+      - name: Run the tests and collect coverage
         env:
           AT_USERNAME: "sandbox"
           AT_API_KEY: ${{ secrets.AT_API_KEY }}
         run: |
-          python -m pytest -v 
+          python -m pytest --cov -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ authlib==1.3.1
 requests==2.32.3
 marshmallow==3.21.3
 africastalking==1.2.7 
- pytest==8.2.2
+pytest==8.2.2
+pytest-cov==5.0.0


### PR DESCRIPTION
- Integrated `Codecov` into the GitHub Actions workflow to check code coverage
- Tests can be executed and coverage collected using `pytest` with the `--cov` flag:

```bash
python -m pytest --cov -v
```