### PR TITLE
Push API image to Heroku registry

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,13 +33,8 @@ jobs:
         run: |
           docker-compose -f "compose.yaml" build
 
-      - name: Tag and push Docker image
-        run: |
-          docker tag customer-orders-service_api registry.heroku.com/customer-orders-service/web
-          docker push registry.heroku.com/customer-orders-service/web
-
-      - name: Deploy to Heroku
+      - name: Push container to Heroku
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
-          heroku container:release web --app customer-orders-service
+          heroku container:push api --app customer-orders-service

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,3 +38,4 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
           heroku container:push api --app customer-orders-service
+          heroku container:release api --app customer-orders-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
 FROM python:3.11-slim
 
+ARG USERNAME=myuser
+ARG UID=1000
+RUN adduser --disabled-password --gecos '' --uid $UID $USERNAME
+
 COPY . /customer-orders-service
 
 WORKDIR /customer-orders-service
 
-RUN pip install -r requirements.txt --default-timeout=100
+RUN pip install --no-cache-dir -r requirements.txt --default-timeout=100
 
 ENV FLASK_APP=run.py
+
+RUN chown -R $USERNAME:$USERNAME /customer-orders-service
+
+USER $USERNAME
 
 EXPOSE 8000
 


### PR DESCRIPTION
- Updated `deploy.yaml` to build, you can push the API directly to the [Heroku container registry](https://devcenter.heroku.com/articles/container-registry-and-runtime) for deployment

*Edit*: API container is released after pushing to Heroku